### PR TITLE
Update dependabot for PNPM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
-version: 2
+version: 8
 updates:
-  - package-ecosystem: '' # See documentation for possible values
-    directory: '/' # Location of package manifests
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
PNPM is only supported in version 8, with a package-ecosystem value of `npm`.